### PR TITLE
Fullscreen Controls Autohide Fix V2

### DIFF
--- a/goodtube.js
+++ b/goodtube.js
@@ -2933,6 +2933,20 @@
 		}
 	}
 
+	/* Fix fullscreen controls not hiding by dispatching a synthetic click 2 seconds after entering fullscreen */
+	function goodTube_fullscreen_fixPlayerControls() {
+		document.addEventListener('fullscreenchange', () => {
+			if (document.fullscreenElement) {
+				setTimeout(() => {
+					if (!document.fullscreenElement) return;
+					document.body.dispatchEvent(new MouseEvent('click', {
+						bubbles: true,
+						cancelable: true
+					}));
+				}, 2000);
+			}
+		});
+	}
 
 	/* Start GoodTube
 	------------------------------------------------------------------------------------------ */
@@ -2948,6 +2962,7 @@
 	else if (window.location.href.indexOf('?goodTubeEmbed=1') !== -1) {
 		goodTube_iframe_init();
 	}
-
+	// Activate fullscreen controls fix
+	goodTube_fullscreen_fixPlayerControls();
 
 })();


### PR DESCRIPTION
This version sends a click to the document.body (I previously thought the click had to be along the edge, but that was just coincidentally safe on my layout) which causes the autohide to wake up. The mousemove event had no effect so it was removed.

I spent a good 15 minutes mashing my F key and had no unexpected pauses with this version, here is the raw link to my modified goodtube.js for ease of testing: https://raw.githubusercontent.com/kfactor072/goodtube/refs/heads/fix/fullscreen-controls/goodtube.js

If this works, try commenting out the mousemove events you mentioned on the previous PR and see if it still works.

